### PR TITLE
feat: 更新下载进度展示并串联 latest 发布同步

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -235,3 +235,11 @@ jobs:
           }
 
           gh release upload $env:TAG @assets --clobber
+
+      - name: Trigger sync-latest-release workflow
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Write-Host "Triggering sync-latest-release workflow for tag: $env:TAG"
+          gh workflow run sync-latest-release.yml -f source_tag="$env:TAG"

--- a/.github/workflows/sync-latest-release.yml
+++ b/.github/workflows/sync-latest-release.yml
@@ -1,8 +1,6 @@
 name: Sync Latest Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       source_tag:

--- a/XhMonitor.Desktop.Tests/CompactUnitFormatterTests.cs
+++ b/XhMonitor.Desktop.Tests/CompactUnitFormatterTests.cs
@@ -6,6 +6,17 @@ namespace XhMonitor.Desktop.Tests;
 public class CompactUnitFormatterTests
 {
     [Theory]
+    [InlineData(768L, "768B")]
+    [InlineData(1536L, "1.5K")]
+    [InlineData(1572864L, "1.5M")]
+    public void FormatSizeFromBytes_ShouldUseShortestUnit(long input, string expected)
+    {
+        var result = CompactUnitFormatter.FormatSizeFromBytes(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData(768, "768M")]
     [InlineData(1536, "1.5G")]
     [InlineData(0.5, "512K")]
@@ -23,6 +34,17 @@ public class CompactUnitFormatterTests
     public void FormatSpeedFromMegabytesPerSecond_ShouldUseShortestUnit(double input, string expected)
     {
         var result = CompactUnitFormatter.FormatSpeedFromMegabytesPerSecond(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(768d, "768B/s")]
+    [InlineData(1536d, "1.5K/s")]
+    [InlineData(1572864d, "1.5M/s")]
+    public void FormatSpeedFromBytesPerSecond_ShouldUseShortestUnit(double input, string expected)
+    {
+        var result = CompactUnitFormatter.FormatSpeedFromBytesPerSecond(input);
 
         result.Should().Be(expected);
     }

--- a/XhMonitor.Desktop.Tests/GitHubAppUpdateServiceTests.cs
+++ b/XhMonitor.Desktop.Tests/GitHubAppUpdateServiceTests.cs
@@ -217,6 +217,65 @@ public sealed class GitHubAppUpdateServiceTests
     }
 
     [Fact]
+    public async Task DownloadUpdateAsync_ShouldReportProgressBytesAndSpeedDuringDownload()
+    {
+        using var tempDir = new TemporaryDirectory();
+        using var handler = new FakeHttpMessageHandler(request =>
+        {
+            if (request.RequestUri!.AbsoluteUri.Contains("/releases/tags/latest", StringComparison.Ordinal))
+            {
+                return CreateJsonResponse("""
+                {
+                  "tag_name": "latest",
+                  "name": "v0.2.13",
+                  "assets": [
+                    {
+                      "name": "XhMonitor-v0.2.13-Lite-Setup.exe",
+                      "browser_download_url": "https://example.com/download/XhMonitor-v0.2.13-Lite-Setup.exe"
+                    }
+                  ]
+                }
+                """);
+            }
+
+            if (request.RequestUri.AbsoluteUri.Contains("/download/", StringComparison.Ordinal))
+            {
+                var bytes = new byte[384 * 1024];
+                var content = new StreamContent(new SlowReadStream(bytes, 128 * 1024, TimeSpan.FromMilliseconds(300)));
+                content.Headers.ContentLength = bytes.Length;
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = content
+                };
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.RequestUri}");
+        });
+
+        var service = CreateService(handler, tempDir.Path, launcher: new FakeInstallerLauncher());
+        var statuses = new List<AppUpdateStatus>();
+        service.StatusChanged += (_, _) => statuses.Add(service.CurrentStatus);
+
+        await service.CheckForUpdatesAsync();
+        statuses.Clear();
+
+        var status = await service.DownloadUpdateAsync();
+
+        status.State.Should().Be(AppUpdateState.Downloaded);
+        statuses.Should().Contain(status =>
+            status.State == AppUpdateState.Downloading &&
+            status.Message != null &&
+            status.Message.Contains("已下载", StringComparison.Ordinal) &&
+            status.Message.Contains("速度", StringComparison.Ordinal));
+        statuses.Should().Contain(status =>
+            status.State == AppUpdateState.Downloading &&
+            status.Message != null &&
+            status.Message.Contains("%", StringComparison.Ordinal) &&
+            status.Message.Contains("/ 384K", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task LaunchInstallerAsync_ShouldAllowReinstallAfterDownload()
     {
         using var tempDir = new TemporaryDirectory();
@@ -399,6 +458,88 @@ public sealed class GitHubAppUpdateServiceTests
             catch
             {
             }
+        }
+    }
+
+    private sealed class SlowReadStream : Stream
+    {
+        private readonly byte[] _data;
+        private readonly int _chunkSize;
+        private readonly TimeSpan _delay;
+        private int _position;
+
+        public SlowReadStream(byte[] data, int chunkSize, TimeSpan delay)
+        {
+            _data = data;
+            _chunkSize = chunkSize;
+            _delay = delay;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _data.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return ReadChunk(buffer.AsSpan(offset, count));
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_position >= _data.Length)
+            {
+                return 0;
+            }
+
+            await Task.Delay(_delay, cancellationToken);
+            return ReadChunk(buffer.Span);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        private int ReadChunk(Span<byte> buffer)
+        {
+            if (_position >= _data.Length)
+            {
+                return 0;
+            }
+
+            var bytesToCopy = Math.Min(Math.Min(buffer.Length, _chunkSize), _data.Length - _position);
+            _data.AsSpan(_position, bytesToCopy).CopyTo(buffer);
+            _position += bytesToCopy;
+            return bytesToCopy;
         }
     }
 }

--- a/XhMonitor.Desktop/Services/CompactUnitFormatter.cs
+++ b/XhMonitor.Desktop/Services/CompactUnitFormatter.cs
@@ -4,6 +4,40 @@ namespace XhMonitor.Desktop.Services;
 
 public static class CompactUnitFormatter
 {
+    public static string FormatSizeFromBytes(long bytes)
+    {
+        if (bytes < 0)
+        {
+            return "--";
+        }
+
+        if (bytes < 1024)
+        {
+            return $"{bytes.ToString(CultureInfo.InvariantCulture)}B";
+        }
+
+        var kilobytes = bytes / 1024d;
+        if (kilobytes < 1024)
+        {
+            return $"{FormatNumber(kilobytes)}K";
+        }
+
+        var megabytes = kilobytes / 1024d;
+        if (megabytes < 1024)
+        {
+            return $"{FormatNumber(megabytes)}M";
+        }
+
+        var gigabytes = megabytes / 1024d;
+        if (gigabytes < 1024)
+        {
+            return $"{FormatNumber(gigabytes)}G";
+        }
+
+        var terabytes = gigabytes / 1024d;
+        return $"{FormatNumber(terabytes)}T";
+    }
+
     public static string FormatMemoryFromMegabytes(double megabytes)
     {
         if (double.IsNaN(megabytes) || double.IsInfinity(megabytes) || megabytes < 0)
@@ -52,6 +86,34 @@ public static class CompactUnitFormatter
 
         var gb = megabytesPerSecond / 1024d;
         return $"{FormatNumber(gb)}G/s";
+    }
+
+    public static string FormatSpeedFromBytesPerSecond(double bytesPerSecond)
+    {
+        if (double.IsNaN(bytesPerSecond) || double.IsInfinity(bytesPerSecond) || bytesPerSecond < 0)
+        {
+            return "--";
+        }
+
+        if (bytesPerSecond < 1024)
+        {
+            return $"{FormatNumber(bytesPerSecond)}B/s";
+        }
+
+        var kilobytesPerSecond = bytesPerSecond / 1024d;
+        if (kilobytesPerSecond < 1024)
+        {
+            return $"{FormatNumber(kilobytesPerSecond)}K/s";
+        }
+
+        var megabytesPerSecond = kilobytesPerSecond / 1024d;
+        if (megabytesPerSecond < 1024)
+        {
+            return $"{FormatNumber(megabytesPerSecond)}M/s";
+        }
+
+        var gigabytesPerSecond = megabytesPerSecond / 1024d;
+        return $"{FormatNumber(gigabytesPerSecond)}G/s";
     }
 
     public static string FormatPercent(double value)

--- a/XhMonitor.Desktop/Services/GitHubAppUpdateService.cs
+++ b/XhMonitor.Desktop/Services/GitHubAppUpdateService.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
@@ -14,8 +15,10 @@ namespace XhMonitor.Desktop.Services;
 public sealed class GitHubAppUpdateService : IAppUpdateService
 {
     private static readonly Regex VersionRegex = new(@"(?<!\d)(\d+\.\d+\.\d+(?:\.\d+)?)", RegexOptions.Compiled);
+    private static readonly TimeSpan DownloadProgressUpdateInterval = TimeSpan.FromMilliseconds(250);
     private const string InstallerSearchPattern = "XhMonitor-v*-Lite-Setup.exe";
     private const string NoNewVersionMessage = "未找到新版本";
+    private const int DownloadBufferSize = 128 * 1024;
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IAppVersionService _appVersionService;
@@ -158,6 +161,7 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
     public async Task<AppUpdateStatus> DownloadUpdateAsync(CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        string? tempFilePath = null;
         try
         {
             if (_latestRelease == null)
@@ -182,7 +186,7 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
             Directory.CreateDirectory(downloadDirectory);
             CleanupInstallerCache(_appVersionService.CurrentVersion, release.InstallerPath);
 
-            var tempFilePath = $"{release.InstallerPath}.download";
+            tempFilePath = $"{release.InstallerPath}.download";
             if (File.Exists(tempFilePath))
             {
                 File.Delete(tempFilePath);
@@ -196,13 +200,16 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
 
             response.EnsureSuccessStatusCode();
 
-            await using (var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
-            await using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
-            {
-                await responseStream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
-            }
+            await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await DownloadInstallerAsync(
+                release,
+                responseStream,
+                tempFilePath,
+                response.Content.Headers.ContentLength,
+                cancellationToken).ConfigureAwait(false);
 
             File.Move(tempFilePath, release.InstallerPath, true);
+            tempFilePath = null;
 
             SetStatus(CreateStatus(
                 AppUpdateState.Downloaded,
@@ -222,6 +229,11 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to download update.");
+            if (!string.IsNullOrWhiteSpace(tempFilePath))
+            {
+                TryDeleteFile(tempFilePath);
+            }
+
             var latestVersion = _latestRelease?.VersionText;
             var latestTag = _latestRelease?.ReleaseTag;
             var assetName = _latestRelease?.AssetName;
@@ -237,6 +249,61 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
         finally
         {
             _gate.Release();
+        }
+    }
+
+    private async Task DownloadInstallerAsync(
+        ResolvedUpdateRelease release,
+        Stream responseStream,
+        string tempFilePath,
+        long? totalBytes,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[DownloadBufferSize];
+        long downloadedBytes = 0;
+        long lastReportedBytes = 0;
+        var stopwatch = Stopwatch.StartNew();
+        var lastReportElapsed = TimeSpan.Zero;
+
+        await using var fileStream = new FileStream(
+            tempFilePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            DownloadBufferSize,
+            useAsync: true);
+
+        while (true)
+        {
+            var bytesRead = await responseStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+            if (bytesRead <= 0)
+            {
+                break;
+            }
+
+            await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+            downloadedBytes += bytesRead;
+
+            var elapsed = stopwatch.Elapsed;
+            if (!ShouldReportDownloadProgress(downloadedBytes, totalBytes, elapsed, lastReportElapsed))
+            {
+                continue;
+            }
+
+            ReportDownloadProgress(release, downloadedBytes, totalBytes, elapsed, lastReportedBytes, lastReportElapsed);
+            lastReportedBytes = downloadedBytes;
+            lastReportElapsed = elapsed;
+        }
+
+        if (downloadedBytes > lastReportedBytes)
+        {
+            ReportDownloadProgress(
+                release,
+                downloadedBytes,
+                totalBytes,
+                stopwatch.Elapsed,
+                lastReportedBytes,
+                lastReportElapsed);
         }
     }
 
@@ -515,6 +582,80 @@ public sealed class GitHubAppUpdateService : IAppUpdateService
     {
         _currentStatus = status;
         StatusChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ReportDownloadProgress(
+        ResolvedUpdateRelease release,
+        long downloadedBytes,
+        long? totalBytes,
+        TimeSpan elapsed,
+        long lastReportedBytes,
+        TimeSpan lastReportElapsed)
+    {
+        SetStatus(CreateStatus(
+            AppUpdateState.Downloading,
+            BuildDownloadProgressMessage(
+                downloadedBytes,
+                totalBytes,
+                CalculateDownloadSpeedBytesPerSecond(downloadedBytes, elapsed, lastReportedBytes, lastReportElapsed)),
+            release.VersionText,
+            release.ReleaseTag,
+            release.AssetName));
+    }
+
+    private static bool ShouldReportDownloadProgress(
+        long downloadedBytes,
+        long? totalBytes,
+        TimeSpan elapsed,
+        TimeSpan lastReportElapsed)
+    {
+        if (downloadedBytes <= 0)
+        {
+            return false;
+        }
+
+        if (totalBytes is > 0 && downloadedBytes >= totalBytes.Value)
+        {
+            return true;
+        }
+
+        return elapsed - lastReportElapsed >= DownloadProgressUpdateInterval;
+    }
+
+    private static double CalculateDownloadSpeedBytesPerSecond(
+        long downloadedBytes,
+        TimeSpan elapsed,
+        long lastReportedBytes,
+        TimeSpan lastReportElapsed)
+    {
+        var deltaBytes = downloadedBytes - lastReportedBytes;
+        var deltaSeconds = (elapsed - lastReportElapsed).TotalSeconds;
+        if (deltaBytes > 0 && deltaSeconds > 0)
+        {
+            return deltaBytes / deltaSeconds;
+        }
+
+        if (downloadedBytes <= 0 || elapsed.TotalSeconds <= 0)
+        {
+            return 0;
+        }
+
+        return downloadedBytes / elapsed.TotalSeconds;
+    }
+
+    private static string BuildDownloadProgressMessage(long downloadedBytes, long? totalBytes, double speedBytesPerSecond)
+    {
+        var downloadedText = CompactUnitFormatter.FormatSizeFromBytes(downloadedBytes);
+        var speedText = CompactUnitFormatter.FormatSpeedFromBytesPerSecond(speedBytesPerSecond);
+
+        if (totalBytes is > 0)
+        {
+            var totalText = CompactUnitFormatter.FormatSizeFromBytes(totalBytes.Value);
+            var progressText = CompactUnitFormatter.FormatPercent(downloadedBytes * 100d / totalBytes.Value);
+            return $"已下载 {downloadedText} / {totalText}（{progressText}），速度 {speedText}";
+        }
+
+        return $"已下载 {downloadedText}，速度 {speedText}";
     }
 
     private static string FormatVersion(Version version)


### PR DESCRIPTION
变更说明
- 为桌面端检查更新下载流程添加实时状态文案，显示已下载大小、总大小、百分比和下载速度。
- 为下载进度补充字节大小与字节速度格式化能力，并新增相关单元测试。
- 调整 release workflow：发布 Lite 安装包后主动触发 sync-latest-release.yml，移除该 workflow 的 release.published 自动触发。

验证
- dotnet test XhMonitor.Desktop.Tests\XhMonitor.Desktop.Tests.csproj --filter "FullyQualifiedName~CompactUnitFormatterTests|FullyQualifiedName~GitHubAppUpdateServiceTests"