### PR TITLE
fix(desktop): desktop widget stability fixes

### DIFF
--- a/.workflow/.debug/DBG-edge-dock-drag-offset-2026-04-05/hypotheses.json
+++ b/.workflow/.debug/DBG-edge-dock-drag-offset-2026-04-05/hypotheses.json
@@ -1,0 +1,39 @@
+{
+  "iteration": 2,
+  "timestamp": "2026-04-05T00:00:00+08:00",
+  "hypotheses": [
+    {
+      "id": "H1",
+      "description": "TaskbarMetricsWindow 混用了设备像素与 WPF 逻辑坐标，导致拖拽增量和吸附计算出现固定比例偏移",
+      "testable_condition": "检查拖拽起点、拖拽增量、屏幕边界是否统一转换为逻辑坐标",
+      "logging_point": "XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs",
+      "evidence_criteria": {
+        "confirm": "发现 PointToScreen / Screen.Bounds / Screen.WorkingArea 直接参与 Left/Top 计算，且没有 TransformFromDevice 转换",
+        "reject": "所有拖拽和吸附计算都已经先转换到同一逻辑坐标系"
+      },
+      "likelihood": 1,
+      "status": "confirmed",
+      "verdict_reason": "源码审查确认拖拽和吸附路径中存在设备像素与 DIP 混算，且 FloatingWindow 已有对应转换实现"
+    },
+    {
+      "id": "H2",
+      "description": "仅修正拖拽起始锚点不足以解决问题，释放吸附与边界钳制路径也存在同类坐标系偏差",
+      "testable_condition": "检查 TrySnapByHalfOut / GetNearestDockSide / ApplyDockSide / ResetToNearestNonTaskbarOverlap 是否仍使用设备像素边界",
+      "logging_point": "XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs",
+      "evidence_criteria": {
+        "confirm": "屏幕边界来自 Screen.Bounds / WorkingArea，直接与 Left / Top / Width / Height 比较",
+        "reject": "所有边界计算都已使用逻辑坐标"
+      },
+      "likelihood": 1,
+      "status": "confirmed",
+      "verdict_reason": "同一文件中的吸附判断和工作区钳制也直接使用了 WinForms 屏幕矩形，需要一并统一坐标"
+    }
+  ],
+  "corrections": [
+    {
+      "wrong_assumption": "偏移只发生在从贴边态切回浮动态的首帧重定位",
+      "corrected_to": "偏移贯穿拖拽增量、释放吸附判断和工作区边界钳制，是系统性的坐标系混用",
+      "reason": "多个路径都直接把设备像素边界或鼠标位置拿去和 WPF 逻辑坐标做运算"
+    }
+  ]
+}

--- a/.workflow/.debug/DBG-edge-dock-drag-offset-2026-04-05/understanding.md
+++ b/.workflow/.debug/DBG-edge-dock-drag-offset-2026-04-05/understanding.md
@@ -1,0 +1,66 @@
+# Understanding Document
+
+**Session ID**: DBG-edge-dock-drag-offset-2026-04-05
+**Bug Description**: 贴边模式下拖拽有偏移，鼠标没有抓住贴边框，贴边框会跑到鼠标右侧一段距离
+**Started**: 2026-04-05T00:00:00+08:00
+
+---
+
+## Exploration Timeline
+
+### Iteration 1 - Initial Exploration (2026-04-05T00:00:00+08:00)
+
+#### Current Understanding
+
+基于 `TaskbarMetricsWindow` 与 `FloatingWindow` 的拖拽/贴边实现对比，问题集中在贴边窗自己的拖拽坐标换算：
+
+- `TaskbarMetricsWindow` 在拖拽开始和拖拽过程中直接使用 `PointToScreen` / `Screen.WorkingArea`。
+- `Window.Left` / `Window.Top`、`ActualWidth` / `ActualHeight` 使用的是 WPF 逻辑坐标（DIP）。
+- `FloatingWindow` 已经实现了 `TransformFromDevice` 的设备像素到逻辑坐标转换，但贴边窗没有复用这层处理。
+
+#### Evidence From Code Search
+
+- `XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs`
+  - `Window_MouseLeftButtonDown` 使用 `PointToScreen(cursorLocal)` 作为拖拽起点。
+  - `Window_MouseMove` 使用 `PointToScreen(e.GetPosition(this))` 计算拖拽增量。
+  - `TrySnapByHalfOut`、`GetNearestDockSide`、`ApplyDockSide`、`ResetToNearestNonTaskbarOverlap` 直接拿 `Screen.Bounds` / `Screen.WorkingArea` 与 `Left` / `Top` 比较。
+- `XhMonitor.Desktop/FloatingWindow.xaml.cs`
+  - 已有 `TransformDevicePointToLogical`、`TransformDeviceRectangleToLogical`，并用来处理屏幕坐标与窗口逻辑坐标之间的转换。
+
+#### Hypotheses Generated
+
+- `H1`: 贴边窗拖拽把设备像素增量直接叠加到逻辑坐标，导致在非 100% DPI 下窗口相对鼠标产生固定比例偏移。
+- `H2`: 贴边状态切换为浮动态时只修正了首帧位置，但释放吸附和边界钳制仍使用设备像素，导致拖拽过程中或释放后继续出现位置漂移。
+
+### Iteration 2 - Resolution (2026-04-05T00:00:00+08:00)
+
+#### Fix Applied
+
+- 在 `TaskbarMetricsWindow` 中新增设备像素 -> 逻辑坐标转换辅助方法，与 `FloatingWindow` 保持一致。
+- 拖拽开始、拖拽移动改为统一使用逻辑屏幕坐标。
+- 吸附判断、最近边识别、工作区钳制改为先把 `Screen.Bounds` / `Screen.WorkingArea` 转成逻辑坐标再参与计算。
+- 为贴边窗坐标转换新增单测，覆盖点和矩形两种缩放场景。
+
+#### Root Cause Identified
+
+**H1 已确认**：`TaskbarMetricsWindow` 混用了 Win32/WinForms 屏幕设备像素与 WPF 窗口逻辑坐标，DPI 缩放下拖拽增量被放大，表现为鼠标没有“抓住”贴边框，窗体跑到鼠标右侧。
+
+#### Lessons Learned
+
+1. 在 WPF 桌面窗体中，只要同时使用 `Screen` / `Cursor` / `PointToScreen` 和 `Window.Left` / `Top`，就必须明确设备像素与逻辑坐标的转换边界。
+2. 修复拖拽起点不足以彻底解决问题，吸附判断和工作区钳制也必须使用同一坐标系。
+
+---
+
+## Current Consolidated Understanding
+
+### What We Know
+- 贴边窗偏移是 DPI 坐标系混用导致，不是拖拽锚点比例算法本身的问题。
+- `FloatingWindow` 已有成熟的坐标转换模式，贴边窗缺失了同等处理。
+- 统一到逻辑坐标后，拖拽、吸附和边界修正会落在同一套坐标系上。
+
+### What Was Disproven
+- ~~仅是 `CalculateWindowTopLeftByDragAnchor` 算法错误~~（该算法只负责从贴边态切回浮动态时保持鼠标落点，问题出在进入拖拽后的坐标增量和后续吸附判断）
+
+### Current Investigation Focus
+验证坐标统一后的编译与单测结果，确认没有引入贴边释放和边界钳制回归。

--- a/.workflow/.debug/DBG-floating-not-topmost-2026-04-05/hypotheses.json
+++ b/.workflow/.debug/DBG-floating-not-topmost-2026-04-05/hypotheses.json
@@ -1,0 +1,141 @@
+{
+  "iteration": 1,
+  "timestamp": "2026-04-05T11:00:08+08:00",
+  "bug": "桌面悬浮窗偶发出现非置顶现象，会被其他窗口挡住。",
+  "hypotheses": [
+    {
+      "id": "H1",
+      "description": "悬浮窗仅依赖 WPF 的 Topmost 属性，缺少在失焦、拖拽、显示切换后的 Win32 级回顶，因此会落到其他 topmost 窗口后面。",
+      "testable_condition": "对比 FloatingWindow 与 TaskbarMetricsWindow 的生命周期处理，确认前者没有 ReassertTopMost / SetWindowPos(HWND_TOPMOST) 兜底。",
+      "logging_point": "XhMonitor.Desktop/FloatingWindow.xaml.cs, XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs",
+      "evidence_criteria": {
+        "confirm": "FloatingWindow 没有等价的回顶逻辑，而 TaskbarMetricsWindow 在 Loaded、SourceInitialized、Deactivated、拖拽结束后都会 ReassertTopMost。",
+        "reject": "FloatingWindow 在关键生命周期里也存在等价的 HWND_TOPMOST 重申逻辑。"
+      },
+      "likelihood": 1,
+      "status": "confirmed"
+    },
+    {
+      "id": "H2",
+      "description": "Show/Hide、托盘菜单、设置窗或关于窗关闭后，悬浮窗只做 Activate 不做 SetWindowPos(HWND_TOPMOST)，导致层级没有被重新抬到 topmost band 顶部。",
+      "testable_condition": "复现托盘显示/隐藏、打开/关闭对话窗等路径，观察窗口是否在这些交互后更容易被挡住。",
+      "logging_point": "XhMonitor.Desktop/Services/WindowManagementService.cs, XhMonitor.Desktop/Services/TrayIconService.cs",
+      "evidence_criteria": {
+        "confirm": "问题主要出现在窗口切换、托盘交互或对话窗关闭后，且代码路径没有显式回顶。",
+        "reject": "这些路径都不会影响层级，问题仅在别的系统窗口类型下出现。"
+      },
+      "likelihood": 1,
+      "status": "confirmed"
+    },
+    {
+      "id": "H3",
+      "description": "用户遇到的是“其他本身也置顶的窗口”或全屏/独占窗口覆盖，而不是悬浮窗完全失去 Topmost。",
+      "testable_condition": "收集复现场景里的遮挡窗口类型，区分普通窗口、同样置顶窗口、全屏窗口。",
+      "logging_point": "runtime reproduction",
+      "evidence_criteria": {
+        "confirm": "只有特定 topmost 或全屏类窗口会遮挡，普通窗口不会。",
+        "reject": "普通非 topmost 窗口也能稳定把悬浮窗压住。"
+      },
+      "likelihood": 2,
+      "status": "pending"
+    },
+    {
+      "id": "H4",
+      "description": "透明分层窗口（AllowsTransparency）叠加多屏/DPI/拖拽切换时暴露了 Z 序维护问题，但本质仍需要通过回顶逻辑兜住。",
+      "testable_condition": "在多屏、缩放变化或跨屏拖拽后复现，观察问题是否更稳定出现。",
+      "logging_point": "XhMonitor.Desktop/FloatingWindow.xaml, runtime reproduction",
+      "evidence_criteria": {
+        "confirm": "问题集中在透明窗口、跨屏或 DPI 变化场景中出现。",
+        "reject": "单屏固定缩放下也可稳定复现，且与显示环境无关。"
+      },
+      "likelihood": 3,
+      "status": "pending"
+    },
+    {
+      "id": "H5",
+      "description": "右侧边缘检测和释放后的回弹使用了 `Math.Max(Width, ActualWidth)`；在 SizeToContent 窗口上 Width/Height 可能为 NaN，导致右/下边界计算失效。",
+      "testable_condition": "检查 FloatingWindow 是否为 SizeToContent 窗口，并验证 `Math.Max(double.NaN, finite)` 的结果是否仍为 NaN。",
+      "logging_point": "XhMonitor.Desktop/FloatingWindow.xaml, XhMonitor.Desktop/FloatingWindow.xaml.cs",
+      "evidence_criteria": {
+        "confirm": "FloatingWindow 使用 SizeToContent，且边缘检测/边界纠偏直接用 Math.Max(Width, ActualWidth)；测试证明该分支在 NaN 下不会回退到 ActualWidth。",
+        "reject": "Width/Height 在拖拽路径中始终为有限值，或右侧逻辑不依赖它们。"
+      },
+      "likelihood": 1,
+      "status": "confirmed"
+    }
+  ],
+  "corrections": [
+    {
+      "wrong_assumption": "当前问题主要是缺少一个置顶菜单开关。",
+      "corrected_to": "更可疑的是悬浮窗缺少和贴边窗口同等级别的 Win32 回顶逻辑；菜单项最多作为补救入口。",
+      "reason": "FloatingWindow 已经在 XAML 中声明 Topmost=True。"
+    }
+  ],
+  "staticFindings": [
+    {
+      "source": "XhMonitor.Desktop/FloatingWindow.xaml",
+      "finding": "悬浮窗已默认 Topmost=True。"
+    },
+    {
+      "source": "XhMonitor.Desktop/FloatingWindow.xaml.cs",
+      "finding": "OnSourceInitialized、HandleWindowDragReleased、SetClickThrough 路径都没有看到 HWND_TOPMOST 回顶。"
+    },
+    {
+      "source": "XhMonitor.Desktop/Services/WindowManagementService.cs",
+      "finding": "显示悬浮窗时仅调用 Show() 和 Activate()。"
+    },
+    {
+      "source": "XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs",
+      "finding": "贴边窗口在 Loaded、SourceInitialized、Deactivated、拖拽结束后都有 ReassertTopMost()。"
+    },
+    {
+      "source": "XhMonitor.Desktop/Services/TrayIconService.cs",
+      "finding": "托盘菜单没有置顶相关入口，只有点击穿透。"
+    },
+    {
+      "source": "XhMonitor.Desktop/Services/WindowManagementService.cs",
+      "finding": "设置窗和关于窗通过 ShowDialog() 打开，关闭后没有显式对悬浮窗重新回顶。"
+    },
+    {
+      "source": "XhMonitor.Desktop/FloatingWindow.xaml.cs + XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs",
+      "finding": "悬浮窗没有 Deactivated 回顶和拖拽结束回顶，而贴边窗口两者都有。"
+    }
+  ],
+  "nextChecks": [
+    "优先按拖拽结束、托盘显示/隐藏、打开设置后关闭三个路径做手工复现。",
+    "区分遮挡窗口是否本身也属于 topmost 或全屏窗口。",
+    "若产品上需要补入口，优先考虑“重新置顶”动作，而不是再次暴露一个默认已为 true 的置顶开关。"
+  ],
+  "fixesApplied": [
+    {
+      "file": "XhMonitor.Desktop/FloatingWindow.xaml.cs",
+      "change": "新增 ReassertTopMost()，通过 SetWindowPos(HWND_TOPMOST) 在悬浮窗 Activated、Deactivated、SourceInitialized、Loaded 和拖拽结束路径重新声明 topmost。"
+    },
+    {
+      "file": "XhMonitor.Desktop/FloatingWindow.xaml.cs",
+      "change": "新增 ResolveWindowDimension()，并在右侧边缘检测与释放后的工作区回弹中改用安全宽高解析，修复 SizeToContent 场景下的 NaN 尺寸问题。"
+    },
+    {
+      "file": "XhMonitor.Desktop.Tests/FloatingWindowDimensionTests.cs",
+      "change": "新增单测覆盖 Width/Height 为 NaN 时对 ActualWidth/ActualHeight 的回退逻辑。"
+    }
+  ],
+  "verification": [
+    {
+      "command": "dotnet build XhMonitor.Desktop/XhMonitor.Desktop.csproj",
+      "result": "passed"
+    },
+    {
+      "command": "dotnet test XhMonitor.Desktop.Tests/XhMonitor.Desktop.Tests.csproj --no-build",
+      "result": "passed (73/73)"
+    },
+    {
+      "command": "dotnet build XhMonitor.Desktop.Tests/XhMonitor.Desktop.Tests.csproj -p:OutDir=C:\\ProjectDev\\project\\xinghe\\xhMonitor\\.codex-temp\\verify2\\ -p:UseAppHost=false",
+      "result": "passed"
+    },
+    {
+      "command": "dotnet test .codex-temp/verify2/XhMonitor.Desktop.Tests.dll",
+      "result": "passed (77/77)"
+    }
+  ]
+}

--- a/.workflow/.debug/DBG-floating-not-topmost-2026-04-05/understanding.md
+++ b/.workflow/.debug/DBG-floating-not-topmost-2026-04-05/understanding.md
@@ -1,0 +1,212 @@
+# Understanding Document
+
+**Session ID**: DBG-floating-not-topmost-2026-04-05  
+**Bug Description**: 用户反馈桌面悬浮窗偶发出现“非置顶”现象，会被其他窗口挡住；先判断可能原因，并评估是否需要在右键菜单补一个置顶相关入口。  
+**Started**: 2026-04-05T11:00:08+08:00
+
+---
+
+## Exploration Timeline
+
+### Iteration 1 - Initial Exploration (2026-04-05 11:00 +08:00)
+
+#### Current Understanding
+
+- 悬浮窗 `FloatingWindow` 在 XAML 上已经声明了 `Topmost="True"`，所以“缺少置顶开关”不是当前现象的直接解释。
+- 贴边窗口 `TaskbarMetricsWindow` 除了 `Topmost="True"`，还在多个生命周期节点调用 Win32 `SetWindowPos(HWND_TOPMOST)` 反复回顶。
+- 悬浮窗当前没有看到与贴边窗口等价的“失焦后回顶”或“拖拽后回顶”逻辑，更多依赖 WPF 的声明式 `Topmost`。
+- 托盘右键菜单目前只有“显示/隐藏”“点击穿透”等动作，没有“重新置顶”或“置顶开关”入口。
+
+#### Evidence from Code Search
+
+- `XhMonitor.Desktop/FloatingWindow.xaml`
+  - 第 13 行声明 `Topmost="True"`。
+- `XhMonitor.Desktop/FloatingWindow.xaml.cs`
+  - `OnSourceInitialized()` 只做句柄获取、位置恢复、位置纠偏和 `WndProc` hook，没有 Win32 级回顶。
+  - `HandleWindowDragReleased()` 在拖拽结束后只尝试切换贴边模式，失败时只做位置纠偏，不做回顶。
+  - `SetClickThrough()` 只切换 `WS_EX_TRANSPARENT`，不涉及 `HWND_TOPMOST`。
+- `XhMonitor.Desktop/Services/WindowManagementService.cs`
+  - `ShowMainWindow()` 仅执行 `_floatingWindow.Show(); _floatingWindow.Activate();`，没有额外回顶。
+- `XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs`
+  - `OnLoaded()`、`OnSourceInitialized()`、`OnDeactivated()`、拖拽结束后都会调用 `ReassertTopMost()`。
+  - `ReassertTopMost()` 通过 `SetWindowPos(hwnd, HWND_TOPMOST, ..., SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER)` 强制回顶。
+- `XhMonitor.Desktop/Services/TrayIconService.cs`
+  - 托盘菜单没有“置顶”相关项，只有“点击穿透”。
+
+#### Hypotheses Generated
+
+- H1：悬浮窗只依赖 WPF 的 `Topmost="True"`，缺少 Win32 级回顶；在失焦、拖拽、显示切换后，窗口可能仍在 topmost band 内，但顺序落到别的 topmost 窗口后面。
+- H2：悬浮窗在 `Show()/Hide()`、设置窗/关于窗打开关闭、托盘交互等场景后，只做 `Activate()` 不做 `SetWindowPos(HWND_TOPMOST)`，导致“看起来像失去置顶”。
+- H3：部分用户口中的“被其他窗口挡住”其实是被同样 topmost 的窗口，甚至全屏/独占窗口覆盖；这种情况下新增“置顶开关”不会修复根因，最多提供一次手动回顶。
+- H4：悬浮窗使用 `AllowsTransparency="True"` 的分层透明窗口，叠加多屏、DPI、拖拽等路径时，更容易暴露 Z 序维护缺口。
+
+---
+
+## Current Consolidated Understanding
+
+### What We Know
+
+- 当前实现里，悬浮窗默认就是置顶窗口，不是“用户忘了开启置顶”。
+- 贴边窗口已经为置顶稳定性做了额外 Win32 兜底，而悬浮窗没有同等级别的兜底。
+- 从静态代码看，最可疑的不是“缺少一个置顶菜单项”，而是“缺少在关键生命周期点重新声明 topmost”的实现。
+
+### What Was Disproven
+
+- ~~悬浮窗完全没有置顶能力~~
+  - `FloatingWindow.xaml` 已明确声明 `Topmost="True"`。
+- ~~右键菜单缺少置顶选项就是根因~~
+  - 菜单缺项只会影响手动补救能力，不解释为什么默认置顶会失效或看起来失效。
+
+### Iteration 2 - Why Only Some Users See It (2026-04-05 11:15 +08:00)
+
+#### New Evidence
+
+- 悬浮窗没有订阅 `Deactivated`，也没有 `ReassertTopMost()`；贴边窗口则明确在 `Deactivated` 中回顶。
+- 悬浮窗拖拽结束后只做“切贴边”判断和位置纠偏，不做回顶；贴边窗口拖拽结束后会回顶。
+- 悬浮窗通过托盘 `Show()/Hide()` 控制显示，显示时只调用 `Show()` + `Activate()`。
+- 设置窗和关于窗通过 `ShowDialog()` 打开，并尽量把悬浮窗设为 `Owner`；关闭对话窗后，没有显式对悬浮窗做重新回顶。
+- 悬浮窗是 `AllowsTransparency="True"` 的分层透明窗口；贴边窗口也是透明窗口，但额外补了 Win32 回顶，所以对环境波动更不敏感。
+
+#### Analysis
+
+这解释了“为什么不是所有用户都遇到”：
+
+- **交互路径不同**
+  - 只要用户不常拖拽、不常从托盘显隐、不常打开设置/关于，问题就可能长期不暴露。
+  - 经常走这些路径的用户，更容易把悬浮窗带到一个没有被重新回顶的层级状态。
+- **竞争窗口不同**
+  - 如果用户桌面上还有别的 topmost/overlay 类窗口，悬浮窗仅靠初始化时那次 `Topmost=True` 更容易被压到后面。
+  - 没有这类软件的用户，即使实现有缺口，也可能感知不到。
+- **显示环境不同**
+  - 多屏、不同 DPI、跨屏拖拽、全屏/无边框应用，会让“Z 序维护缺口”更容易被触发或放大。
+  - 单屏、固定缩放、普通办公窗口环境下，现有实现可能看起来一直正常。
+- **使用习惯不同**
+  - 有些用户可能会进入点击穿透、频繁切换锁定/展开、通过托盘恢复窗口；这些都会增加窗口层级被系统或其他窗口重排的机会。
+
+#### Updated Understanding
+
+- 问题更像“代码里存在稳定性缺口，但只有在某些交互和环境条件下才暴露”，不是“只有部分机器代码路径不同”。
+- 因此“部分用户不复现”并不能反证代码没问题，只说明他们还没踩中触发条件。
+
+---
+
+## Current Consolidated Understanding (Updated)
+
+### What We Know
+
+- 当前实现里，悬浮窗默认就是置顶窗口，不是“用户忘了开启置顶”。
+- 贴边窗口已经为置顶稳定性做了额外 Win32 兜底，而悬浮窗没有同等级别的兜底。
+- 悬浮窗的风险主要集中在这些交互点：
+  - 拖拽结束
+  - 托盘显示/隐藏
+  - 打开/关闭设置或关于窗口
+  - 与其他 topmost/overlay/fullscreen 窗口竞争 Z 序
+- “有些用户有问题、有些用户没有”更符合“触发条件不同”而不是“代码行为随机”。
+
+### What Was Disproven
+
+- ~~悬浮窗完全没有置顶能力~~
+  - `FloatingWindow.xaml` 已明确声明 `Topmost="True"`。
+- ~~右键菜单缺少置顶选项就是根因~~
+  - 菜单缺项只会影响手动补救能力，不解释为什么默认置顶会失效或看起来失效。
+- ~~只有用户机器差异，代码本身没问题~~
+  - 代码中确实存在与贴边窗口不一致的置顶维护缺口。
+
+### Current Investigation Focus
+
+- 优先验证悬浮窗是否在以下路径后掉出预期层级：
+  - 拖拽结束后
+  - 托盘显示/隐藏后
+  - 打开/关闭设置或关于窗口后
+  - 与其他 topmost 窗口同时存在时
+- 如果需要补交互入口，更准确的产品语义应偏向“重新置顶”或“恢复前台层级”，而不是单纯再加一个“置顶开关”。
+
+### Iteration 3 - Minimal Fix Applied (2026-04-05 11:25 +08:00)
+
+#### Fix Applied
+
+- 修改 `XhMonitor.Desktop/FloatingWindow.xaml.cs`
+  - 为悬浮窗补充 `SetWindowPos(HWND_TOPMOST)` 级别的 `ReassertTopMost()`。
+  - 在窗口 `Activated` / `Deactivated` 时通过 `Dispatcher.BeginInvoke` 重新声明 topmost。
+  - 在 `OnSourceInitialized()` 和 `OnLoaded()` 后补一次回顶，覆盖启动和首次显示路径。
+  - 在拖拽结束且未切换到贴边模式时，再补一次回顶，覆盖用户最容易触发的问题路径。
+
+#### Verification Results
+
+- `dotnet build XhMonitor.Desktop/XhMonitor.Desktop.csproj`：通过。
+- `dotnet test XhMonitor.Desktop.Tests/XhMonitor.Desktop.Tests.csproj --no-build`：通过（73 / 73）。
+
+#### Updated Understanding
+
+- 现在悬浮窗在关键生命周期点已经与贴边窗口具备同类的 topmost 重申机制。
+- 这属于“最小根修”，优先补实现缺口，而不是先增加一个手动菜单补救项。
+
+### Iteration 4 - Right Edge Detection Gap Confirmed (2026-04-05 11:45 +08:00)
+
+#### New Evidence
+
+- `FloatingWindow` 本身是 `SizeToContent="WidthAndHeight"`。
+- 右侧边缘检测和释放后的边界纠偏都直接使用：
+  - `Math.Max(Width, ActualWidth)`
+  - `Math.Max(Height, ActualHeight)`
+- 对当前窗口来说，`Width` / `Height` 可能是 `NaN`；而 `Math.Max(double.NaN, 60)` 仍会得到 `NaN`，不能自动回退到 `ActualWidth`。
+- 这会导致右侧/下侧相关计算拿到无效尺寸，进而让：
+  - 拖拽释放后的边缘检测失真；
+  - 工作区边界纠偏失效。
+
+#### Fix Applied
+
+- 修改 `XhMonitor.Desktop/FloatingWindow.xaml.cs`
+  - 为悬浮窗新增 `ResolveWindowDimension(width, actualWidth, fallback)`。
+  - 在 `TryActivateEdgeDockModeOnDragRelease()` 中改用安全尺寸解析，确保右/下边缘检测可用。
+  - 在 `ResetToNearestNonTaskbarOverlap()` 中改用安全尺寸解析，确保释放后会被拉回工作区。
+- 新增 `XhMonitor.Desktop.Tests/FloatingWindowDimensionTests.cs`
+  - 覆盖 `Width/Height = NaN`、`ActualWidth/ActualHeight` 有值时的回退逻辑。
+
+#### Verification Results
+
+- 常规 `dotnet build` 会因为正在运行的 `XhMonitor.Desktop.exe` 锁住 `bin/Debug` 输出而失败，这不是源码错误。
+- 使用独立输出目录验证通过：
+  - `dotnet build XhMonitor.Desktop.Tests/XhMonitor.Desktop.Tests.csproj -p:OutDir=C:\ProjectDev\project\xinghe\xhMonitor\.codex-temp\verify2\ -p:UseAppHost=false`
+  - `dotnet test .codex-temp/verify2/XhMonitor.Desktop.Tests.dll`
+- 结果：77 / 77 通过。
+
+#### Updated Understanding
+
+- 用户描述的“左侧不会越出边界，但右侧可以拖出边界”是合理的：
+  - 左侧更像是系统拖拽行为在兜底；
+  - 右侧则暴露了我们自己的宽度解析缺口。
+- 这不是“没有右侧边缘检测”，而是“右侧边缘检测在 `NaN` 尺寸下失效”。
+
+---
+
+## Current Consolidated Understanding (Latest)
+
+### What We Know
+
+- 当前实现里，悬浮窗默认就是置顶窗口，不是“用户忘了开启置顶”。
+- 贴边窗口已经为置顶稳定性做了额外 Win32 兜底，而悬浮窗原先没有同等级别的兜底。
+- 悬浮窗的风险主要集中在这些交互点：
+  - 拖拽结束
+  - 托盘显示/隐藏
+  - 打开/关闭设置或关于窗口
+  - 与其他 topmost/overlay/fullscreen 窗口竞争 Z 序
+- “有些用户有问题、有些用户没有”更符合“触发条件不同”而不是“代码行为随机”。
+- 已对悬浮窗补上最小回顶修复，优先覆盖启动、激活、失焦、拖拽结束四类关键路径。
+- 已确认右侧越界问题来自 `SizeToContent` 窗口的 `NaN` 宽高参与边缘检测/边界纠偏计算。
+- 已补安全宽高解析，覆盖右侧边缘检测和释放后的工作区回弹。
+
+### What Was Disproven
+
+- ~~悬浮窗完全没有置顶能力~~
+  - `FloatingWindow.xaml` 已明确声明 `Topmost="True"`。
+- ~~右键菜单缺少置顶选项就是根因~~
+  - 菜单缺项只会影响手动补救能力，不解释为什么默认置顶会失效或看起来失效。
+- ~~只有用户机器差异，代码本身没问题~~
+  - 代码中确实存在与贴边窗口不一致的置顶维护缺口。
+
+### Current Fix Status
+
+- 已为悬浮窗补上 Win32 级 `ReassertTopMost()` 兜底。
+- 已为悬浮窗补上 `ResolveWindowDimension()`，修复 `NaN` 宽高导致的右侧越界问题。
+- 自动化验证已通过独立输出目录下的编译和桌面测试。

--- a/XhMonitor.Desktop.Tests/FloatingWindowCoordinateTransformTests.cs
+++ b/XhMonitor.Desktop.Tests/FloatingWindowCoordinateTransformTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using System.Windows;
+using System.Windows.Media;
+
+namespace XhMonitor.Desktop.Tests;
+
+public class FloatingWindowCoordinateTransformTests
+{
+    [Fact]
+    public void TransformDevicePointToLogical_ShouldScaleWithoutTranslation()
+    {
+        var transform = new Matrix(0.8, 0, 0, 0.8, 0, 0);
+
+        var point = FloatingWindow.TransformDevicePointToLogical(new Point(1000, 500), transform);
+
+        point.X.Should().Be(800);
+        point.Y.Should().Be(400);
+    }
+
+    [Fact]
+    public void TransformDeviceRectangleToLogical_ShouldScaleBoundsWithoutOffset()
+    {
+        var transform = new Matrix(0.8, 0, 0, 0.8, 0, 0);
+
+        var rect = FloatingWindow.TransformDeviceRectangleToLogical(
+            new global::System.Drawing.Rectangle(100, 200, 400, 300),
+            transform);
+
+        rect.Left.Should().Be(80);
+        rect.Top.Should().Be(160);
+        rect.Right.Should().Be(400);
+        rect.Bottom.Should().Be(400);
+    }
+}

--- a/XhMonitor.Desktop.Tests/FloatingWindowDimensionTests.cs
+++ b/XhMonitor.Desktop.Tests/FloatingWindowDimensionTests.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+
+namespace XhMonitor.Desktop.Tests;
+
+public class FloatingWindowDimensionTests
+{
+    [Theory]
+    [InlineData(double.NaN, 60, 320, 60)]
+    [InlineData(double.NaN, 0, 320, 320)]
+    [InlineData(280, double.NaN, 320, 280)]
+    [InlineData(0, 0, 320, 320)]
+    public void ResolveWindowDimension_ShouldReturnExpectedDimension(double width, double actualWidth, double fallback, double expected)
+    {
+        var dimension = FloatingWindow.ResolveWindowDimension(width, actualWidth, fallback);
+
+        dimension.Should().Be(expected);
+    }
+}

--- a/XhMonitor.Desktop.Tests/TaskbarMetricsWindowCoordinateTransformTests.cs
+++ b/XhMonitor.Desktop.Tests/TaskbarMetricsWindowCoordinateTransformTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using System.Windows;
+using System.Windows.Media;
+using XhMonitor.Desktop.Windows;
+
+namespace XhMonitor.Desktop.Tests;
+
+public class TaskbarMetricsWindowCoordinateTransformTests
+{
+    [Fact]
+    public void TransformDevicePointToLogical_ShouldScaleWithoutTranslation()
+    {
+        var transform = new Matrix(0.8, 0, 0, 0.8, 0, 0);
+
+        var point = TaskbarMetricsWindow.TransformDevicePointToLogical(new Point(1000, 500), transform);
+
+        point.X.Should().Be(800);
+        point.Y.Should().Be(400);
+    }
+
+    [Fact]
+    public void TransformDeviceRectangleToLogical_ShouldScaleBoundsWithoutOffset()
+    {
+        var transform = new Matrix(0.8, 0, 0, 0.8, 0, 0);
+
+        var rect = TaskbarMetricsWindow.TransformDeviceRectangleToLogical(
+            new global::System.Drawing.Rectangle(100, 200, 400, 300),
+            transform);
+
+        rect.Left.Should().Be(80);
+        rect.Top.Should().Be(160);
+        rect.Right.Should().Be(400);
+        rect.Bottom.Should().Be(400);
+    }
+}

--- a/XhMonitor.Desktop/FloatingWindow.xaml.cs
+++ b/XhMonitor.Desktop/FloatingWindow.xaml.cs
@@ -27,6 +27,11 @@ public partial class FloatingWindow : Window
 {
     private const int GWL_EXSTYLE = -20;
     private const long WS_EX_TRANSPARENT = 0x20L;
+    private static readonly IntPtr HwndTopMost = new(-1);
+    private const uint SwpNoSize = 0x0001;
+    private const uint SwpNoMove = 0x0002;
+    private const uint SwpNoActivate = 0x0010;
+    private const uint SwpNoOwnerZOrder = 0x0200;
     private const double DRAG_THRESHOLD = 5.0; // 拖动阈值(像素)
     private const double EDGE_DOCK_SNAP_DISTANCE = 24.0; // 贴边触发的近边阈值(像素)
     private const string ScrollViewerVerticalScrollBarPartName = "PART_VerticalScrollBar";
@@ -93,6 +98,8 @@ public partial class FloatingWindow : Window
 
         _positionStore = new WindowPositionStore("XhMonitor.Desktop");
 
+        Activated += OnActivated;
+        Deactivated += OnDeactivated;
         Loaded += OnLoaded;
         SourceInitialized += OnSourceInitialized;
         MouseLeftButtonDown += OnMouseLeftButtonDown;
@@ -292,6 +299,8 @@ public partial class FloatingWindow : Window
 
     private async void OnLoaded(object? sender, RoutedEventArgs e)
     {
+        ReassertTopMost();
+
         try
         {
             await _viewModel.InitializeAsync();
@@ -388,6 +397,17 @@ public partial class FloatingWindow : Window
 
         _hwndSource = HwndSource.FromHwnd(_windowHandle);
         _hwndSource?.AddHook(WndProc);
+        ReassertTopMost();
+    }
+
+    private void OnActivated(object? sender, EventArgs e)
+    {
+        Dispatcher.BeginInvoke(new Action(ReassertTopMost), DispatcherPriority.Background);
+    }
+
+    private void OnDeactivated(object? sender, EventArgs e)
+    {
+        Dispatcher.BeginInvoke(new Action(ReassertTopMost), DispatcherPriority.Background);
     }
 
     private void OnMouseLeftButtonDown(object? sender, MouseButtonEventArgs e)
@@ -1083,9 +1103,9 @@ public partial class FloatingWindow : Window
     {
         var screen = WinFormsScreen.FromPoint(WinFormsCursor.Position);
         // 完整屏幕边界：用于“半窗越界”触发。
-        var screenBounds = screen.Bounds;
+        var screenBounds = ConvertScreenRectangleToWindowCoordinates(screen.Bounds);
         // 工作区边界：仅用于识别任务栏所在方向，避免把任务栏边缘当作贴边触发。
-        var workingBounds = screen.WorkingArea;
+        var workingBounds = ConvertScreenRectangleToWindowCoordinates(screen.WorkingArea);
 
         // 若某一侧存在任务栏占位，则该方向不触发悬浮窗 -> 迷你/贴边切换。
         var hasTaskbarOnLeft = workingBounds.Left > screenBounds.Left;
@@ -1098,8 +1118,8 @@ public partial class FloatingWindow : Window
         var boundaryRight = screenBounds.Right;
         var boundaryBottom = screenBounds.Bottom;
 
-        var windowWidth = Math.Max(Width, ActualWidth);
-        var windowHeight = Math.Max(Height, ActualHeight);
+        var windowWidth = ResolveWindowDimension(Width, ActualWidth, 320);
+        var windowHeight = ResolveWindowDimension(Height, ActualHeight, 60);
 
         var overflowLeft = Math.Max(0, boundaryLeft - Left);
         var overflowRight = Math.Max(0, (Left + windowWidth) - boundaryRight);
@@ -1123,7 +1143,7 @@ public partial class FloatingWindow : Window
         var nearBottom = !hasTaskbarOnBottom && screenBottomDistance <= EDGE_DOCK_SNAP_DISTANCE;
         var triggerByNearScreenEdge = nearLeft || nearRight || nearTop || nearBottom;
 
-        var cursor = WinFormsCursor.Position;
+        var cursor = ConvertScreenPointToLogicalCoordinates(WinFormsCursor.Position.X, WinFormsCursor.Position.Y);
         var cursorNearLeft = !hasTaskbarOnLeft && Math.Abs(cursor.X - boundaryLeft) <= EDGE_DOCK_SNAP_DISTANCE;
         var cursorNearRight = !hasTaskbarOnRight && Math.Abs(boundaryRight - cursor.X) <= EDGE_DOCK_SNAP_DISTANCE;
         var cursorNearTop = !hasTaskbarOnTop && Math.Abs(cursor.Y - boundaryTop) <= EDGE_DOCK_SNAP_DISTANCE;
@@ -1187,11 +1207,13 @@ public partial class FloatingWindow : Window
         StopLongPressTimer();
         System.Diagnostics.Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [主控制栏] 拖动结束");
 
-        var activated = TryActivateEdgeDockModeOnDragRelease(out _, out _);
+        var activated = TryActivateEdgeDockModeOnDragRelease(out var reason, out var detail);
+        System.Diagnostics.Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [边缘检测] activated={activated}, reason={reason}, detail={detail}");
 
         if (!activated)
         {
             ResetToNearestNonTaskbarOverlapByMouseScreen();
+            ReassertTopMost();
         }
     }
 
@@ -1211,9 +1233,9 @@ public partial class FloatingWindow : Window
 
     private void ResetToNearestNonTaskbarOverlap(WinFormsScreen screen)
     {
-        var workingArea = screen.WorkingArea;
-        var windowWidth = Math.Max(Width, ActualWidth);
-        var windowHeight = Math.Max(Height, ActualHeight);
+        var workingArea = ConvertScreenRectangleToWindowCoordinates(screen.WorkingArea);
+        var windowWidth = ResolveWindowDimension(Width, ActualWidth, 320);
+        var windowHeight = ResolveWindowDimension(Height, ActualHeight, 60);
 
         var minLeft = workingArea.Left;
         var maxLeft = workingArea.Right - windowWidth;
@@ -1244,6 +1266,84 @@ public partial class FloatingWindow : Window
         return Math.Clamp(value, min, max);
     }
 
+    internal static double ResolveWindowDimension(double width, double actualWidth, double fallback)
+    {
+        var hasWidth = double.IsFinite(width) && width > 0;
+        var hasActualWidth = double.IsFinite(actualWidth) && actualWidth > 0;
+
+        if (hasWidth && hasActualWidth)
+        {
+            return Math.Max(width, actualWidth);
+        }
+
+        if (hasWidth)
+        {
+            return width;
+        }
+
+        if (hasActualWidth)
+        {
+            return actualWidth;
+        }
+
+        if (!double.IsFinite(fallback) || fallback <= 0)
+        {
+            return 0;
+        }
+
+        return fallback;
+    }
+
+    private Rect ConvertScreenRectangleToWindowCoordinates(global::System.Drawing.Rectangle rectangle)
+    {
+        return TransformDeviceRectangleToLogical(rectangle, GetDeviceToLogicalTransform());
+    }
+
+    private System.Windows.Point ConvertScreenPointToLogicalCoordinates(int x, int y)
+    {
+        return TransformDevicePointToLogical(new System.Windows.Point(x, y), GetDeviceToLogicalTransform());
+    }
+
+    private Matrix GetDeviceToLogicalTransform()
+    {
+        return _hwndSource?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+    }
+
+    internal static System.Windows.Point TransformDevicePointToLogical(System.Windows.Point point, Matrix deviceToLogicalTransform)
+    {
+        return deviceToLogicalTransform.Transform(point);
+    }
+
+    internal static Rect TransformDeviceRectangleToLogical(global::System.Drawing.Rectangle rectangle, Matrix deviceToLogicalTransform)
+    {
+        var topLeft = TransformDevicePointToLogical(new System.Windows.Point(rectangle.Left, rectangle.Top), deviceToLogicalTransform);
+        var bottomRight = TransformDevicePointToLogical(new System.Windows.Point(rectangle.Right, rectangle.Bottom), deviceToLogicalTransform);
+
+        var left = Math.Min(topLeft.X, bottomRight.X);
+        var top = Math.Min(topLeft.Y, bottomRight.Y);
+        var right = Math.Max(topLeft.X, bottomRight.X);
+        var bottom = Math.Max(topLeft.Y, bottomRight.Y);
+
+        return new Rect(left, top, Math.Max(0, right - left), Math.Max(0, bottom - top));
+    }
+
+    private void ReassertTopMost()
+    {
+        if (_windowHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        _ = SetWindowPos(
+            _windowHandle,
+            HwndTopMost,
+            0,
+            0,
+            0,
+            0,
+            SwpNoMove | SwpNoSize | SwpNoActivate | SwpNoOwnerZOrder);
+    }
+
     private static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
     {
         return IntPtr.Size == 8
@@ -1269,6 +1369,17 @@ public partial class FloatingWindow : Window
 
     [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
     private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(
+        IntPtr hWnd,
+        IntPtr hWndInsertAfter,
+        int x,
+        int y,
+        int cx,
+        int cy,
+        uint uFlags);
 
     private void RegisterExitHotkey()
     {

--- a/XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs
+++ b/XhMonitor.Desktop/Windows/TaskbarMetricsWindow.xaml.cs
@@ -58,6 +58,7 @@ public partial class TaskbarMetricsWindow : Window
     private static readonly WpfColor SideGlowColor = WpfColor.FromRgb(0xE6, 0x9F, 0x00);
 
     private readonly TaskbarMetricsViewModel _viewModel;
+    private HwndSource? _hwndSource;
     private bool _allowClose;
 
     private bool _isDragging;
@@ -138,7 +139,7 @@ public partial class TaskbarMetricsWindow : Window
     private void ActivateDockFromCursorFallback()
     {
         var screen = GetMouseScreen();
-        var cursor = WinFormsCursor.Position;
+        var cursor = GetMousePositionInLogicalCoordinates();
 
         _manualPlacement = false;
         _isDockedVisual = true;
@@ -161,6 +162,7 @@ public partial class TaskbarMetricsWindow : Window
 
     private void OnSourceInitialized(object? sender, EventArgs e)
     {
+        _hwndSource = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
         RefreshPlacementToDockAnchor();
         ReassertTopMost();
     }
@@ -233,7 +235,7 @@ public partial class TaskbarMetricsWindow : Window
     private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
         var cursorLocal = e.GetPosition(this);
-        var cursorScreen = PointToScreen(cursorLocal);
+        var cursorScreen = ConvertScreenPointToLogicalCoordinates(PointToScreen(cursorLocal));
 
         _dragStartedFromDockedVisual = _isDockedVisual;
 
@@ -270,7 +272,7 @@ public partial class TaskbarMetricsWindow : Window
             return;
         }
 
-        var currentScreen = PointToScreen(e.GetPosition(this));
+        var currentScreen = GetMousePositionInLogicalCoordinates();
         var delta = currentScreen - _dragStartScreen;
         Left = _windowStart.X + delta.X;
         Top = _windowStart.Y + delta.Y;
@@ -325,7 +327,7 @@ public partial class TaskbarMetricsWindow : Window
 
     private bool TrySnapByHalfOut(WinFormsScreen screen)
     {
-        var bounds = screen.Bounds;
+        var bounds = ConvertScreenRectangleToLogicalCoordinates(screen.Bounds);
         var windowWidth = Math.Max(Width, ActualWidth);
         var windowHeight = Math.Max(Height, ActualHeight);
 
@@ -343,7 +345,7 @@ public partial class TaskbarMetricsWindow : Window
 
     private EdgeDockSide GetNearestDockSide(WinFormsScreen screen, out double minDistance)
     {
-        var work = screen.WorkingArea;
+        var work = ConvertScreenRectangleToLogicalCoordinates(screen.WorkingArea);
         var windowWidth = Math.Max(Width, ActualWidth);
         var windowHeight = Math.Max(Height, ActualHeight);
 
@@ -371,10 +373,10 @@ public partial class TaskbarMetricsWindow : Window
         return EdgeDockSide.Bottom;
     }
 
-    private static EdgeDockSide GetNearestDockSideByCursor(WinFormsScreen screen)
+    private EdgeDockSide GetNearestDockSideByCursor(WinFormsScreen screen)
     {
-        var work = screen.WorkingArea;
-        var cursor = WinFormsCursor.Position;
+        var work = ConvertScreenRectangleToLogicalCoordinates(screen.WorkingArea);
+        var cursor = GetMousePositionInLogicalCoordinates();
 
         var leftDistance = Math.Abs(cursor.X - work.Left);
         var rightDistance = Math.Abs(work.Right - cursor.X);
@@ -408,7 +410,7 @@ public partial class TaskbarMetricsWindow : Window
 
         ApplyWindowSize(isDocked: true, dockSide);
 
-        var work = screen.WorkingArea;
+        var work = ConvertScreenRectangleToLogicalCoordinates(screen.WorkingArea);
         var minLeft = work.Left + EdgeSnapMargin;
         var maxLeft = work.Right - Width - EdgeSnapMargin;
         var minTop = work.Top + EdgeSnapMargin;
@@ -539,7 +541,7 @@ public partial class TaskbarMetricsWindow : Window
 
     private void ResetToNearestNonTaskbarOverlap(WinFormsScreen screen)
     {
-        var workingArea = screen.WorkingArea;
+        var workingArea = ConvertScreenRectangleToLogicalCoordinates(screen.WorkingArea);
         var windowWidth = Math.Max(Width, ActualWidth);
         var windowHeight = Math.Max(Height, ActualHeight);
 
@@ -566,6 +568,11 @@ public partial class TaskbarMetricsWindow : Window
     private static WinFormsScreen GetMouseScreen()
     {
         return WinFormsScreen.FromPoint(WinFormsCursor.Position);
+    }
+
+    private WpfPoint GetMousePositionInLogicalCoordinates()
+    {
+        return ConvertScreenPointToLogicalCoordinates(WinFormsCursor.Position.X, WinFormsCursor.Position.Y);
     }
 
     private static double ClampToRange(double value, double min, double max)
@@ -602,6 +609,44 @@ public partial class TaskbarMetricsWindow : Window
         }
 
         return value;
+    }
+
+    private WpfPoint ConvertScreenPointToLogicalCoordinates(int x, int y)
+    {
+        return ConvertScreenPointToLogicalCoordinates(new WpfPoint(x, y));
+    }
+
+    private WpfPoint ConvertScreenPointToLogicalCoordinates(WpfPoint point)
+    {
+        return TransformDevicePointToLogical(point, GetDeviceToLogicalTransform());
+    }
+
+    private Rect ConvertScreenRectangleToLogicalCoordinates(global::System.Drawing.Rectangle rectangle)
+    {
+        return TransformDeviceRectangleToLogical(rectangle, GetDeviceToLogicalTransform());
+    }
+
+    private Matrix GetDeviceToLogicalTransform()
+    {
+        return _hwndSource?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+    }
+
+    internal static WpfPoint TransformDevicePointToLogical(WpfPoint point, Matrix deviceToLogicalTransform)
+    {
+        return deviceToLogicalTransform.Transform(point);
+    }
+
+    internal static Rect TransformDeviceRectangleToLogical(global::System.Drawing.Rectangle rectangle, Matrix deviceToLogicalTransform)
+    {
+        var topLeft = TransformDevicePointToLogical(new WpfPoint(rectangle.Left, rectangle.Top), deviceToLogicalTransform);
+        var bottomRight = TransformDevicePointToLogical(new WpfPoint(rectangle.Right, rectangle.Bottom), deviceToLogicalTransform);
+
+        var left = Math.Min(topLeft.X, bottomRight.X);
+        var top = Math.Min(topLeft.Y, bottomRight.Y);
+        var right = Math.Max(topLeft.X, bottomRight.X);
+        var bottom = Math.Max(topLeft.Y, bottomRight.Y);
+
+        return new Rect(left, top, Math.Max(0, right - left), Math.Max(0, bottom - top));
     }
 
     private static double ResolveAnchorRatio(double cursorOffset, double sourceSize)


### PR DESCRIPTION
## Summary
- stabilize floating window z-order and edge rebound
- correct edge-dock drag offset caused by mixed device/logical coordinates under DPI scaling
- add TaskbarMetricsWindow coordinate transform tests and debug notes

## Testing
- dotnet test XhMonitor.Desktop.Tests/XhMonitor.Desktop.Tests.csproj --filter "FullyQualifiedName~TaskbarMetricsWindow|FullyQualifiedName~FloatingWindowCoordinateTransform"