### PR TITLE
fix(ci): 优化 release-lite 工作流中运行时检测日志的字符串格式化

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -126,7 +126,7 @@ jobs:
             $runtimePath = Join-Path $RuntimeDir $ExpectedFile
             if (Test-Path $runtimePath) {
               $size = (Get-Item $runtimePath).Length / 1MB
-              Write-Host "Using existing $DisplayName: $runtimePath ($([math]::Round($size, 2)) MB)"
+              Write-Host ("Using existing {0}: {1} ({2} MB)" -f $DisplayName, $runtimePath, [math]::Round($size, 2))
               return
             }
 


### PR DESCRIPTION
将 Write-Host 中的内联变量插值 `$DisplayName: $runtimePath ($([math]::Round($size, 2)) MB)`
改为 PowerShell -f 格式化运算符 `("Using existing {0}: {1} ({2} MB)" -f ...)`

原因：内联 $() 嵌套在 GitHub Actions YAML 上下文中容易引发解析歧义，
-f 运算符语法更清晰，参数与模板分离，降低转义风险。

影响：仅影响日志输出格式，无功能变更。