### PR TITLE
feat(desktop): 添加 Web 服务监听状态展示，修复服务启动顺序

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.9</Version>
-    <AssemblyVersion>0.2.9.0</AssemblyVersion>
-    <FileVersion>0.2.9.0</FileVersion>
+    <Version>0.2.17</Version>
+    <AssemblyVersion>0.2.17.0</AssemblyVersion>
+    <FileVersion>0.2.17.0</FileVersion>
     <SystemManagementVersion>10.0.2</SystemManagementVersion>
   </PropertyGroup>
 </Project>

--- a/XhMonitor.Desktop.Tests/ApplicationHostedServiceTests.cs
+++ b/XhMonitor.Desktop.Tests/ApplicationHostedServiceTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using XhMonitor.Desktop.Services;
+
+namespace XhMonitor.Desktop.Tests;
+
+public class ApplicationHostedServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ShouldStartBackendBeforeWeb()
+    {
+        var calls = new List<string>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var backendService = new FakeBackendServerService(() => calls.Add("backend"));
+        var webService = new FakeWebServerService(
+            onStart: () =>
+            {
+                calls.Add("web");
+                cts.Cancel();
+            });
+
+        var service = new ApplicationHostedService(
+            backendService,
+            webService,
+            NullLogger<ApplicationHostedService>.Instance);
+
+        var executeAsync = typeof(ApplicationHostedService).GetMethod(
+            "ExecuteAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        executeAsync.Should().NotBeNull();
+
+        var task = (Task?)executeAsync!.Invoke(service, new object[] { cts.Token });
+        task.Should().NotBeNull();
+
+        await task!;
+
+        calls.Should().Equal("backend", "web");
+    }
+
+    private sealed class FakeBackendServerService : IBackendServerService
+    {
+        private readonly Action _onStart;
+
+        public FakeBackendServerService(Action onStart)
+        {
+            _onStart = onStart;
+        }
+
+        public bool IsRunning { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = true;
+            _onStart();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public Task RestartAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = true;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class FakeWebServerService : IWebServerService
+    {
+        private readonly Action _onStart;
+
+        public FakeWebServerService(Action onStart)
+        {
+            _onStart = onStart;
+        }
+
+        public bool IsRunning { get; private set; }
+        public WebServerBindingMode CurrentBindingMode { get; } = WebServerBindingMode.Localhost;
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = true;
+            _onStart();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/XhMonitor.Desktop.Tests/GitHubAppUpdateServiceTests.cs
+++ b/XhMonitor.Desktop.Tests/GitHubAppUpdateServiceTests.cs
@@ -84,17 +84,17 @@ public sealed class GitHubAppUpdateServiceTests
     public async Task CheckForUpdatesAsync_ShouldReturnUpToDate_AndDeleteInstallerMatchingCurrentVersion()
     {
         using var tempDir = new TemporaryDirectory();
-        var cachedInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.9-Lite-Setup.exe");
+        var cachedInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.17-Lite-Setup.exe");
         await File.WriteAllBytesAsync(cachedInstallerPath, [1, 2, 3]);
 
         using var handler = new FakeHttpMessageHandler(_ => CreateJsonResponse("""
         {
           "tag_name": "latest",
-          "name": "v0.2.9",
+          "name": "v0.2.17",
           "assets": [
             {
-              "name": "XhMonitor-v0.2.9-Lite-Setup.exe",
-              "browser_download_url": "https://example.com/download/XhMonitor-v0.2.9-Lite-Setup.exe"
+              "name": "XhMonitor-v0.2.17-Lite-Setup.exe",
+              "browser_download_url": "https://example.com/download/XhMonitor-v0.2.17-Lite-Setup.exe"
             }
           ]
         }
@@ -114,7 +114,7 @@ public sealed class GitHubAppUpdateServiceTests
     {
         using var tempDir = new TemporaryDirectory();
         var staleInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.8-Lite-Setup.exe");
-        var currentInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.9-Lite-Setup.exe");
+        var currentInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.17-Lite-Setup.exe");
         var latestInstallerPath = Path.Combine(tempDir.Path, "XhMonitor-v0.2.13-Lite-Setup.exe");
         await File.WriteAllBytesAsync(staleInstallerPath, [1]);
         await File.WriteAllBytesAsync(currentInstallerPath, [2]);
@@ -384,7 +384,7 @@ public sealed class GitHubAppUpdateServiceTests
     {
         public Version CurrentVersion => new(0, 2, 9);
 
-        public string CurrentVersionText => "0.2.9";
+        public string CurrentVersionText => "0.2.17";
     }
 
     private sealed class FakeTrayIconService : ITrayIconService

--- a/XhMonitor.Desktop.Tests/SettingsViewModelTests.cs
+++ b/XhMonitor.Desktop.Tests/SettingsViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using XhMonitor.Desktop.Services;
 using XhMonitor.Desktop.ViewModels;
 using Xunit;
@@ -17,10 +18,33 @@ public class SettingsViewModelTests
         public int WebPort { get; init; } = 35180;
     }
 
+    private sealed class FakeWebServerService : IWebServerService
+    {
+        public bool IsRunning { get; set; }
+        public WebServerBindingMode CurrentBindingMode { get; set; } = WebServerBindingMode.Unknown;
+
+        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static SettingsViewModel CreateViewModel(
+        FakeServiceDiscovery? serviceDiscovery = null,
+        FakeWebServerService? webServerService = null)
+    {
+        return new SettingsViewModel(
+            new HttpClient(),
+            serviceDiscovery ?? new FakeServiceDiscovery(),
+            webServerService ?? new FakeWebServerService(),
+            NullLogger<SettingsViewModel>.Instance);
+    }
+
     [Fact]
     public void LocalIpEndpoint_ShouldAppendPort_ForSingleIp()
     {
-        var vm = new SettingsViewModel(new HttpClient(), new FakeServiceDiscovery { WebPort = 35180 });
+        var vm = CreateViewModel(new FakeServiceDiscovery { WebPort = 35180 });
         vm.LocalIpAddress = "10.0.0.1";
 
         vm.LocalIpEndpoint.Should().Be("10.0.0.1:35180");
@@ -29,7 +53,7 @@ public class SettingsViewModelTests
     [Fact]
     public void LocalIpEndpoint_ShouldAppendPort_ForMultipleIps()
     {
-        var vm = new SettingsViewModel(new HttpClient(), new FakeServiceDiscovery { WebPort = 35180 });
+        var vm = CreateViewModel(new FakeServiceDiscovery { WebPort = 35180 });
         vm.LocalIpAddress = "10.0.0.1, 192.168.1.2";
 
         vm.LocalIpEndpoint.Should().Be("10.0.0.1:35180, 192.168.1.2:35180");
@@ -38,7 +62,7 @@ public class SettingsViewModelTests
     [Fact]
     public void LocalIpEndpoint_ShouldFallbackToPortHint_WhenNoValidIp()
     {
-        var vm = new SettingsViewModel(new HttpClient(), new FakeServiceDiscovery { WebPort = 35180 });
+        var vm = CreateViewModel(new FakeServiceDiscovery { WebPort = 35180 });
         vm.LocalIpAddress = "未检测到";
 
         vm.LocalIpEndpoint.Should().Be("未检测到 (端口 35180)");
@@ -47,7 +71,7 @@ public class SettingsViewModelTests
     [Fact]
     public void DockVisualStyle_ShouldNormalizeToBar_WhenInputInvalid()
     {
-        var vm = new SettingsViewModel(new HttpClient(), new FakeServiceDiscovery());
+        var vm = CreateViewModel();
 
         vm.DockVisualStyle = "unknown-style";
 
@@ -57,10 +81,27 @@ public class SettingsViewModelTests
     [Fact]
     public void DockVisualStyle_ShouldKeepText_WhenInputIsText()
     {
-        var vm = new SettingsViewModel(new HttpClient(), new FakeServiceDiscovery());
+        var vm = CreateViewModel();
 
         vm.DockVisualStyle = "Text";
 
         vm.DockVisualStyle.Should().Be("Text");
+    }
+
+    [Theory]
+    [InlineData(WebServerBindingMode.Lan, "当前实际监听：0.0.0.0:35180（局域网可访问）")]
+    [InlineData(WebServerBindingMode.Localhost, "当前实际监听：localhost:35180（仅本机可访问）")]
+    [InlineData(WebServerBindingMode.Unknown, "当前实际监听：未知（Web 服务尚未启动或状态未刷新）")]
+    public void RefreshWebServerBindingStatus_ShouldMapRuntimeBindingModeToMessage(
+        WebServerBindingMode bindingMode,
+        string expectedMessage)
+    {
+        var webServerService = new FakeWebServerService { CurrentBindingMode = bindingMode };
+        var vm = CreateViewModel(new FakeServiceDiscovery { WebPort = 35180 }, webServerService);
+
+        vm.RefreshWebServerBindingStatus();
+
+        vm.WebServerBindingMode.Should().Be(bindingMode);
+        vm.WebServerBindingMessage.Should().Be(expectedMessage);
     }
 }

--- a/XhMonitor.Desktop/Services/ApplicationHostedService.cs
+++ b/XhMonitor.Desktop/Services/ApplicationHostedService.cs
@@ -24,10 +24,11 @@ public sealed class ApplicationHostedService : BackgroundService
     {
         try
         {
-            _logger.LogInformation("Starting backend and web services.");
-            await Task.WhenAll(
-                _backendService.StartAsync(stoppingToken),
-                _webService.StartAsync(stoppingToken)).ConfigureAwait(false);
+            _logger.LogInformation("Starting backend service.");
+            await _backendService.StartAsync(stoppingToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Backend service is ready. Starting web service.");
+            await _webService.StartAsync(stoppingToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/XhMonitor.Desktop/Services/IWebServerService.cs
+++ b/XhMonitor.Desktop/Services/IWebServerService.cs
@@ -1,8 +1,16 @@
 namespace XhMonitor.Desktop.Services;
 
+public enum WebServerBindingMode
+{
+    Unknown = 0,
+    Localhost = 1,
+    Lan = 2
+}
+
 public interface IWebServerService : IAsyncDisposable
 {
     bool IsRunning { get; }
+    WebServerBindingMode CurrentBindingMode { get; }
 
     Task StartAsync(CancellationToken cancellationToken = default);
 

--- a/XhMonitor.Desktop/Services/WebServerService.cs
+++ b/XhMonitor.Desktop/Services/WebServerService.cs
@@ -25,6 +25,7 @@ public sealed class WebServerService : IWebServerService
     private readonly SemaphoreSlim _gate = new(1, 1);
     private Task? _webServerTask;
     private CancellationTokenSource? _webServerCts;
+    private volatile WebServerBindingMode _currentBindingMode = WebServerBindingMode.Unknown;
 
     public WebServerService(IServiceDiscovery serviceDiscovery, HttpClient httpClient)
     {
@@ -34,6 +35,7 @@ public sealed class WebServerService : IWebServerService
     }
 
     public bool IsRunning => _webServerTask != null && !_webServerTask.IsCompleted;
+    public WebServerBindingMode CurrentBindingMode => _currentBindingMode;
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
@@ -75,12 +77,14 @@ public sealed class WebServerService : IWebServerService
                     {
                         builder.WebHost.UseKestrel(options => { options.ListenAnyIP(_webPort); });
                         builder.WebHost.UseUrls($"http://*:{_webPort}");
+                        _currentBindingMode = WebServerBindingMode.Lan;
                         Debug.WriteLine($"Web server configured for LAN access (0.0.0.0:{_webPort})");
                     }
                     else
                     {
                         builder.WebHost.UseKestrel(options => { options.ListenLocalhost(_webPort); });
                         builder.WebHost.UseUrls($"http://localhost:{_webPort}");
+                        _currentBindingMode = WebServerBindingMode.Localhost;
                         Debug.WriteLine($"Web server configured for localhost only");
                     }
 
@@ -235,6 +239,7 @@ public sealed class WebServerService : IWebServerService
                 }
                 catch (Exception ex)
                 {
+                    _currentBindingMode = WebServerBindingMode.Unknown;
                     Debug.WriteLine($"Web server error: {ex.Message}");
                 }
             }, _webServerCts.Token);
@@ -291,11 +296,13 @@ public sealed class WebServerService : IWebServerService
             _webServerCts?.Dispose();
             _webServerCts = null;
             _webServerTask = null;
+            _currentBindingMode = WebServerBindingMode.Unknown;
 
             Debug.WriteLine("Web frontend server stopped successfully");
         }
         catch (Exception ex)
         {
+            _currentBindingMode = WebServerBindingMode.Unknown;
             Debug.WriteLine($"Error stopping web server: {ex.Message}");
         }
     }

--- a/XhMonitor.Desktop/ViewModels/SettingsViewModel.cs
+++ b/XhMonitor.Desktop/ViewModels/SettingsViewModel.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using XhMonitor.Core.Common;
 using XhMonitor.Core.Configuration;
 using XhMonitor.Desktop.Services;
@@ -18,6 +19,8 @@ public class SettingsViewModel : INotifyPropertyChanged
 {
     private readonly HttpClient _httpClient;
     private readonly string _apiBaseUrl;
+    private readonly IWebServerService _webServerService;
+    private readonly ILogger<SettingsViewModel> _logger;
     // 端口属于基础设施配置：由服务端 appsettings.json (Server:Port) 管理，不在数据库/设置界面中暴露。
 
     // 外观设置
@@ -63,15 +66,23 @@ public class SettingsViewModel : INotifyPropertyChanged
     // Service 状态
     private bool _serviceIsAdmin = false;
     private string _serviceAdminMessage = string.Empty;
+    private WebServerBindingMode _webServerBindingMode = WebServerBindingMode.Unknown;
+    private string _webServerBindingMessage = "Web 监听状态未知";
 
     private bool _isSaving = false;
 
     /// <param name="httpClient">HttpClient instance from IHttpClientFactory</param>
-    public SettingsViewModel(HttpClient httpClient, IServiceDiscovery serviceDiscovery)
+    public SettingsViewModel(
+        HttpClient httpClient,
+        IServiceDiscovery serviceDiscovery,
+        IWebServerService webServerService,
+        ILogger<SettingsViewModel> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _webPort = serviceDiscovery.WebPort;
         _apiBaseUrl = $"{serviceDiscovery.ApiBaseUrl.TrimEnd('/')}/api/v1/config";
+        _webServerService = webServerService ?? throw new ArgumentNullException(nameof(webServerService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public string ThemeColor
@@ -325,6 +336,18 @@ public class SettingsViewModel : INotifyPropertyChanged
         set => SetProperty(ref _serviceAdminMessage, value);
     }
 
+    public WebServerBindingMode WebServerBindingMode
+    {
+        get => _webServerBindingMode;
+        private set => SetProperty(ref _webServerBindingMode, value);
+    }
+
+    public string WebServerBindingMessage
+    {
+        get => _webServerBindingMessage;
+        private set => SetProperty(ref _webServerBindingMessage, value ?? string.Empty);
+    }
+
     public bool IsSaving
     {
         get => _isSaving;
@@ -414,6 +437,7 @@ public class SettingsViewModel : INotifyPropertyChanged
 
             // 加载 Service 管理员状态
             await LoadAdminStatusAsync();
+            RefreshWebServerBindingStatus();
 
             return Result<bool, string>.Success(true);
         }
@@ -540,6 +564,26 @@ public class SettingsViewModel : INotifyPropertyChanged
         {
             ServiceIsAdmin = false;
             ServiceAdminMessage = "无法连接到 Service";
+        }
+    }
+
+    public void RefreshWebServerBindingStatus()
+    {
+        try
+        {
+            WebServerBindingMode = _webServerService.CurrentBindingMode;
+            WebServerBindingMessage = _webServerService.CurrentBindingMode switch
+            {
+                WebServerBindingMode.Lan => $"当前实际监听：0.0.0.0:{WebPort}（局域网可访问）",
+                WebServerBindingMode.Localhost => $"当前实际监听：localhost:{WebPort}（仅本机可访问）",
+                _ => "当前实际监听：未知（Web 服务尚未启动或状态未刷新）"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to refresh web server binding status.");
+            WebServerBindingMode = WebServerBindingMode.Unknown;
+            WebServerBindingMessage = "当前实际监听：未知（读取失败）";
         }
     }
 

--- a/XhMonitor.Desktop/Windows/SettingsWindow.xaml
+++ b/XhMonitor.Desktop/Windows/SettingsWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:services="clr-namespace:XhMonitor.Desktop.Services"
         mc:Ignorable="d"
         Title="XhMonitor 设置" Height="720" Width="1080"
         MinWidth="760" MinHeight="640"
@@ -570,6 +571,54 @@
                                                     </Style>
                                                 </TextBlock.Style>
                                             </TextBlock>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Web 实际监听状态 -->
+                                    <Border Margin="0,12,0,0"
+                                            Padding="10,6"
+                                            CornerRadius="4"
+                                            HorizontalAlignment="Stretch">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="Background" Value="#2D2D30"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Lan}">
+                                                        <Setter Property="Background" Value="#1E3A1E"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Localhost}">
+                                                        <Setter Property="Background" Value="#1E2A3A"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Unknown}">
+                                                        <Setter Property="Background" Value="#3A2A1E"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Fill" Value="#888888"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Lan}">
+                                                                <Setter Property="Fill" Value="#4CAF50"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Localhost}">
+                                                                <Setter Property="Fill" Value="#64B5F6"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding WebServerBindingMode}" Value="{x:Static services:WebServerBindingMode.Unknown}">
+                                                                <Setter Property="Fill" Value="#FFB74D"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
+                                            <TextBlock Text="{Binding WebServerBindingMessage}"
+                                                       FontSize="12"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{StaticResource TextPrimary}"
+                                                       TextWrapping="Wrap"/>
                                         </StackPanel>
                                     </Border>
                                 </StackPanel>

--- a/XhMonitor.Desktop/Windows/SettingsWindow.xaml.cs
+++ b/XhMonitor.Desktop/Windows/SettingsWindow.xaml.cs
@@ -84,6 +84,7 @@ public partial class SettingsWindow : Window
             // 仅在窗口加载时查询一次开机自启动状态，避免每次保存都触发外部命令。
             _originalStartupEnabled = _startupManager.IsStartupEnabled();
             _viewModel.StartWithWindows = _originalStartupEnabled;
+            _viewModel.RefreshWebServerBindingStatus();
             UpdateResponsiveLayout(ActualWidth);
         };
     }
@@ -232,6 +233,7 @@ public partial class SettingsWindow : Window
                         {
                             // 仅管理员模式变更，重启Service即可
                             await _backendServerService.RestartAsync();
+                            _viewModel.RefreshWebServerBindingStatus();
 
                             // Service 重启后，主动重连 SignalR 以刷新 Power 等指标状态
                             if (Owner is FloatingWindow fw)
@@ -263,6 +265,7 @@ public partial class SettingsWindow : Window
                 await ShowSaveSuccessHintAsync();
             }
 
+            _viewModel.RefreshWebServerBindingStatus();
             // 更新原始值，避免重复提示
             _viewModel.UpdateOriginalAdminMode();
             _viewModel.UpdateOriginalEnableLanAccess();

--- a/xhmonitor-web/package.json
+++ b/xhmonitor-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xhmonitor-web",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.17",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
变更内容：
- 新增 WebServerBindingMode 枚举（Unknown/Localhost/Lan）， 用于表示 Web 服务的实际监听模式
- IWebServerService 接口增加 CurrentBindingMode 属性， WebServerService 在启动/停止/异常时维护该状态
- SettingsViewModel 增加 WebServerBindingMode 和 WebServerBindingMessage 属性，提供 RefreshWebServerBindingStatus() 方法从运行时服务读取实际监听状态并映射为中文提示
- SettingsWindow 设置页新增监听状态指示器，根据模式显示 不同颜色（绿色=LAN、蓝色=Localhost、橙色=未知）
- ApplicationHostedService 将后端与 Web 服务的并行启动改为 顺序启动，确保后端就绪后再启动 Web 服务，避免依赖缺失

变更原因：
- 用户无法直观判断 Web 服务实际监听的是 localhost 还是 0.0.0.0，配置与实际运行状态可能不一致
- 并行启动时 Web 服务可能在后端未就绪时启动，导致初始请求失败

影响范围：
- SettingsViewModel 构造函数签名变更（新增 IWebServerService、 ILogger 参数），所有调用方需同步更新
- ApplicationHostedService 启动时序从并行变为顺序， 总启动时间略增但可靠性提升
- 新增 ApplicationHostedServiceTests 验证启动顺序
- SettingsViewModelTests 新增绑定状态映射测试用例