### PR TITLE
fix: 修复 SQLite 相对路径误连空库

### DIFF
--- a/.workflow/specs/debug-notes.md
+++ b/.workflow/specs/debug-notes.md
@@ -1,0 +1,30 @@
+---
+title: "Debug Notes"
+dimension: specs
+category: debug
+keywords:
+  - debug
+  - root-cause
+  - diagnostics
+readMode: optional
+priority: normal
+---
+
+# Debug Notes
+
+<spec-entry category="debug" keywords="sqlite,current-directory,ryzenadj,relative-path,native-interop" date="2026-05-18" source="XhMonitor.Service/Data/SqliteConnectionStringResolver.cs:1; XhMonitor.Core/Services/RyzenAdjNativeClient.cs:218">
+
+### SQLite 相对路径不得依赖全局当前目录
+
+服务端 SQLite 连接串中的相对 `Data Source` 必须在启动时解析为基于应用目录的绝对路径，不能依赖 `Environment.CurrentDirectory`。后台服务、native interop、外部进程或第三方库可能临时修改进程级当前目录，导致 SQLite 创建或连接到错误位置的空数据库。
+
+本次故障表现为日志持续出现 `SQLite Error 1: 'no such table: ProcessMetricRecords'`、`ApplicationSettings`、`AggregatedMetricRecords`，同时现场出现 `Service/tools/RyzenAdj/xhmonitor.db` 这个 4 KB 空库。根因是 `RyzenAdjNativeClient` 为加载 native DLL 修改了全局 `Environment.CurrentDirectory`，而连接串 `Data Source=xhmonitor.db` 在并发创建连接时被解析到了 `tools/RyzenAdj`。
+
+规则：
+
+- SQLite `Data Source` 如果是相对路径，启动时必须基于 `ContentRootPath` / 应用目录转成绝对路径。
+- native interop 不得修改全局 `Environment.CurrentDirectory`；优先使用显式 DLL 路径、`SetDllDirectory` 或受控加载策略。
+- 诊断类似缺表错误时，同时检查实际连接的数据库文件路径、误创建的空库、文件创建时间和日志首个异常时间。
+- 修复这类问题时应补充路径解析测试，覆盖相对路径、绝对路径和 `:memory:`。
+
+</spec-entry>

--- a/XhMonitor.Core/Services/RyzenAdjNativeClient.cs
+++ b/XhMonitor.Core/Services/RyzenAdjNativeClient.cs
@@ -218,15 +218,11 @@ public sealed class RyzenAdjNativeClient : IRyzenAdjCli, IDisposable
 
     private sealed class NativeLibraryDirectoryScope : IDisposable
     {
-        private readonly string _previousDirectory;
-
         private NativeLibraryDirectoryScope(string? directory)
         {
-            _previousDirectory = Environment.CurrentDirectory;
             if (!string.IsNullOrWhiteSpace(directory))
             {
                 SetDllDirectory(directory);
-                Environment.CurrentDirectory = directory;
             }
         }
 
@@ -236,7 +232,6 @@ public sealed class RyzenAdjNativeClient : IRyzenAdjCli, IDisposable
         public void Dispose()
         {
             SetDllDirectory(null);
-            Environment.CurrentDirectory = _previousDirectory;
         }
     }
 

--- a/XhMonitor.Service/Data/SqliteConnectionStringResolver.cs
+++ b/XhMonitor.Service/Data/SqliteConnectionStringResolver.cs
@@ -1,0 +1,24 @@
+using Microsoft.Data.Sqlite;
+
+namespace XhMonitor.Service.Data;
+
+public static class SqliteConnectionStringResolver
+{
+    public static string ResolveDataSourcePath(string connectionString, string baseDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseDirectory);
+
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        var dataSource = builder.DataSource;
+        if (string.IsNullOrWhiteSpace(dataSource) ||
+            dataSource == ":memory:" ||
+            Path.IsPathRooted(dataSource))
+        {
+            return builder.ConnectionString;
+        }
+
+        builder.DataSource = Path.GetFullPath(Path.Combine(baseDirectory, dataSource));
+        return builder.ConnectionString;
+    }
+}

--- a/XhMonitor.Service/Program.cs
+++ b/XhMonitor.Service/Program.cs
@@ -127,7 +127,9 @@ try
         return;
     }
 
-    var connectionString = connectionResult.Value;
+    var connectionString = SqliteConnectionStringResolver.ResolveDataSourcePath(
+        connectionResult.Value,
+        appDirectory);
 
 builder.Services.AddDbContextFactory<MonitorDbContext>(options =>
 {

--- a/XhMonitor.Tests/Data/SqliteConnectionStringResolverTests.cs
+++ b/XhMonitor.Tests/Data/SqliteConnectionStringResolverTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using XhMonitor.Service.Data;
+
+namespace XhMonitor.Tests.Data;
+
+public class SqliteConnectionStringResolverTests
+{
+    [Fact]
+    public void ResolveDataSourcePath_WhenDataSourceIsRelative_AnchorsPathToBaseDirectory()
+    {
+        var result = SqliteConnectionStringResolver.ResolveDataSourcePath(
+            "Data Source=xhmonitor.db;Mode=ReadWriteCreate;Cache=Shared",
+            @"C:\Program Files\XhMonitor\Service");
+        var builder = new SqliteConnectionStringBuilder(result);
+
+        builder.DataSource.Should().Be(@"C:\Program Files\XhMonitor\Service\xhmonitor.db");
+        builder.Mode.Should().Be(SqliteOpenMode.ReadWriteCreate);
+        builder.Cache.Should().Be(SqliteCacheMode.Shared);
+    }
+
+    [Fact]
+    public void ResolveDataSourcePath_WhenDataSourceIsAbsolute_KeepsOriginalPath()
+    {
+        var result = SqliteConnectionStringResolver.ResolveDataSourcePath(
+            @"Data Source=C:\Data\xhmonitor.db;Mode=ReadWriteCreate",
+            @"C:\Program Files\XhMonitor\Service");
+        var builder = new SqliteConnectionStringBuilder(result);
+
+        builder.DataSource.Should().Be(@"C:\Data\xhmonitor.db");
+    }
+
+    [Fact]
+    public void ResolveDataSourcePath_WhenDataSourceIsInMemory_KeepsInMemoryDatabase()
+    {
+        var result = SqliteConnectionStringResolver.ResolveDataSourcePath(
+            "Data Source=:memory:",
+            @"C:\Program Files\XhMonitor\Service");
+
+        result.Should().Be("Data Source=:memory:");
+    }
+}


### PR DESCRIPTION
## 变更内容
- 将 SQLite 相对 Data Source 解析为基于 Service 应用目录的绝对路径，避免受 Environment.CurrentDirectory 影响
- 移除 RyzenAdj native 加载时对全局 Environment.CurrentDirectory 的修改
- 增加 SQLite 连接串路径解析单测，覆盖相对路径、绝对路径和 :memory:
- 记录本次缺表/空库问题到 debug spec

## 验证
- dotnet test XhMonitor.Tests/XhMonitor.Tests.csproj --no-restore --filter "SqliteConnectionStringResolverTests|RyzenAdjCliTests|RyzenAdjFallbackClientTests"
- dotnet build xhMonitor.sln --no-restore
