### PR TITLE
fix: 优化温度传感器选择策略，过滤无效传感器

### DIFF
--- a/XhMonitor.Core/Providers/SystemMetricProvider.cs
+++ b/XhMonitor.Core/Providers/SystemMetricProvider.cs
@@ -328,26 +328,52 @@ public class SystemMetricProvider : ISystemMetricProvider, IAsyncDisposable, IDi
     {
         var typeSet = hardwareTypes.ToHashSet();
         var matching = sensors
-            .Where(s => typeSet.Contains(s.HardwareType) && IsUsableTemperature(s.Value))
+            .Where(s => typeSet.Contains(s.HardwareType) &&
+                        IsUsableTemperature(s.Value) &&
+                        IsTemperatureSensorNameUsable(s.Name))
             .ToList();
         if (matching.Count == 0)
         {
             return null;
         }
 
-        var preferred = matching
-            .Where(s =>
-                s.Name.Contains("Package", StringComparison.OrdinalIgnoreCase) ||
-                s.Name.Contains("Core", StringComparison.OrdinalIgnoreCase) ||
-                s.Name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(s => s.Value)
-            .FirstOrDefault();
-        var selected = preferred ?? matching.OrderByDescending(s => s.Value).First();
+        var selected = SelectPreferredTemperatureSensor(matching);
         return Math.Round(selected.Value, 1);
     }
 
     private static bool IsUsableTemperature(float value)
         => !float.IsNaN(value) && !float.IsInfinity(value) && value > 0;
+
+    private static bool IsTemperatureSensorNameUsable(string name)
+        => !name.Contains("Distance to TjMax", StringComparison.OrdinalIgnoreCase);
+
+    private static SensorReading SelectPreferredTemperatureSensor(IReadOnlyList<SensorReading> sensors)
+    {
+        var coreMax = sensors.FirstOrDefault(s => s.Name.Equals("Core Max", StringComparison.OrdinalIgnoreCase));
+        if (coreMax != null)
+        {
+            return coreMax;
+        }
+
+        var package = sensors.FirstOrDefault(s =>
+            s.Name.Equals("CPU Package", StringComparison.OrdinalIgnoreCase) ||
+            s.Name.Contains("Package", StringComparison.OrdinalIgnoreCase) ||
+            s.Name.Contains("Tctl", StringComparison.OrdinalIgnoreCase) ||
+            s.Name.Contains("Tdie", StringComparison.OrdinalIgnoreCase) ||
+            s.Name.Contains("Hot Spot", StringComparison.OrdinalIgnoreCase));
+        if (package != null)
+        {
+            return package;
+        }
+
+        var average = sensors.FirstOrDefault(s => s.Name.Equals("Core Average", StringComparison.OrdinalIgnoreCase));
+        if (average != null)
+        {
+            return average;
+        }
+
+        return sensors.OrderByDescending(s => s.Value).First();
+    }
 
     private void LogInvalidTemperatureSensorsOnce(
         IReadOnlyList<SensorReading> sensors,

--- a/XhMonitor.Tests/Providers/SystemMetricProviderTests.cs
+++ b/XhMonitor.Tests/Providers/SystemMetricProviderTests.cs
@@ -252,6 +252,41 @@ public class SystemMetricProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task DoneWhen_GetSystemUsageAsync_ReadsIntelCoreMaxAndIgnoresDistanceToTjMax()
+    {
+        var hardwareManager = new Mock<ILibreHardwareManager>();
+        hardwareManager.SetupGet(m => m.IsAvailable).Returns(true);
+        hardwareManager
+            .Setup(m => m.GetSensorValues(It.IsAny<IReadOnlyCollection<HardwareType>>(), It.IsAny<SensorType>()))
+            .Returns((IReadOnlyCollection<HardwareType> types, SensorType sensorType) =>
+            {
+                if (sensorType != SensorType.Temperature)
+                {
+                    return new List<SensorReading>();
+                }
+
+                return new List<SensorReading>
+                {
+                    new(HardwareType.Cpu, "12th Gen Intel Core i7-12700H", SensorType.Temperature, "Core Average", 53.3f),
+                    new(HardwareType.Cpu, "12th Gen Intel Core i7-12700H", SensorType.Temperature, "P-Core #4", 54.0f),
+                    new(HardwareType.Cpu, "12th Gen Intel Core i7-12700H", SensorType.Temperature, "CPU Package", 63.0f),
+                    new(HardwareType.Cpu, "12th Gen Intel Core i7-12700H", SensorType.Temperature, "Core Max", 70.0f),
+                    new(HardwareType.Cpu, "12th Gen Intel Core i7-12700H", SensorType.Temperature, "P-Core #4 Distance to TjMax", 90.0f)
+                };
+            });
+
+        using var provider = new SystemMetricProvider(
+            Array.Empty<IMetricProvider>(),
+            logger: null,
+            hardwareManager: hardwareManager.Object,
+            verifiedPhysicalAdapterSignatures: Array.Empty<string>());
+
+        var usage = await provider.GetSystemUsageAsync();
+
+        usage.CpuTemperature.Should().Be(70.0);
+    }
+
+    [Fact]
     public async Task DoneWhen_GetSystemUsageAsync_FallsBackToVirtualAdapters_WhenNoPhysicalAdaptersMatched()
     {
         var hardwareManager = new Mock<ILibreHardwareManager>();


### PR DESCRIPTION
- 新增 IsTemperatureSensorNameUsable 过滤器，排除 "Distance to TjMax" 类传感器（该值为距最高温度的 差值，并非实际温度读数，此前会被误当作高温优先选中）
- 提取 SelectPreferredTemperatureSensor 方法，建立明确的 传感器优先级：Core Max > Package/Tctl/Tdie/Hot Spot > Core Average > 最高温度值兜底
- 新增测试验证 Intel 平台下 Core Max 优先选中且 Distance to TjMax 被正确过滤

影响：修复 Intel 平台 CPU 温度显示偏高的问题，AMD 平台
行为不变（Tctl/Tdie 仍可正常选中）